### PR TITLE
gui-wm/river: Removed -Dexamples

### DIFF
--- a/gui-wm/river/river-9999.ebuild
+++ b/gui-wm/river/river-9999.ebuild
@@ -48,7 +48,6 @@ src_configure() {
 		-Drelease-safe
 		-Dxwayland=true
 		-Dman-pages=true
-		-Dexamples=false
 		"${EXTRA_ECONF[@]}"
 	)
 	export CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}"


### PR DESCRIPTION
Package-Manager: Portage-3.0.20, Repoman-3.0.3

Current river doesn't support the -Dexamples flag anymore, apparently.