### PR TITLE
gui-apps/qtgreet: keyword for ~riscv

### DIFF
--- a/gui-apps/qtgreet/qtgreet-1.0.0.ebuild
+++ b/gui-apps/qtgreet/qtgreet-1.0.0.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	SRC_URI="https://gitlab.com/marcusbritanicus/QtGreet/-/archive/v${PV}/QtGreet-v${PV}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}"/QtGreet-v${PV}
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~riscv"
 fi
 
 CMAKE_USE_DIR="${S}"/src

--- a/gui-apps/qtgreet/qtgreet-1.0.0a_p20210127.ebuild
+++ b/gui-apps/qtgreet/qtgreet-1.0.0a_p20210127.ebuild
@@ -15,7 +15,7 @@ else
 	COMMIT=5c9d8acd92942eb8ab30a9cea1fd1847ca648741
 	SRC_URI="https://gitlab.com/marcusbritanicus/QtGreet/-/archive/${COMMIT}/QtGreet-${COMMIT}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}"/QtGreet-${COMMIT}
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~riscv"
 fi
 
 CMAKE_USE_DIR="${S}"/src


### PR DESCRIPTION
Tested on HiFive Unmatched.