### PR TITLE
gui-apps/fuzzel: Correct build flags

### DIFF
--- a/gui-apps/fuzzel/fuzzel-1.6.5.ebuild
+++ b/gui-apps/fuzzel/fuzzel-1.6.5.ebuild
@@ -1,5 +1,6 @@
 # Copyright 2021 Aisha Tammy
 # Copyright 2021 Erik Rodriguez
+# Copyright 2022 Ryan Fox
 # Distributed under the terms of the ISC License
 
 EAPI=7
@@ -42,8 +43,8 @@ BDEPEND="
 src_configure() {
 	local emesonargs=(
 		-Dwerror=false
-		-Dpng-backend=$(usex png none libpng)
-		-Dsvg-backend=$(usex svg none librsvg)
+		-Dpng-backend=$(usex png libpng none)
+		-Dsvg-backend=$(usex svg librsvg none)
 		$(meson_feature cairo enable-cairo)
 	)
 	meson_src_configure

--- a/gui-apps/fuzzel/fuzzel-1.6.5.ebuild
+++ b/gui-apps/fuzzel/fuzzel-1.6.5.ebuild
@@ -8,11 +8,11 @@ EAPI=7
 inherit meson xdg
 
 DESCRIPTION="Application launcher similar to rofi's 'drun' mode"
-HOMEPAGE="https://codeberg.org/dnkl/yambar"
+HOMEPAGE="https://codeberg.org/dnkl/fuzzel"
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://codeberg.org/dnkl/fuzzel"
+	EGIT_REPO_URI="https://codeberg.org/dnkl/fuzzel.git"
 else
 	SRC_URI="https://codeberg.org/dnkl/fuzzel/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}"/${PN}

--- a/gui-apps/fuzzel/fuzzel-9999.ebuild
+++ b/gui-apps/fuzzel/fuzzel-9999.ebuild
@@ -1,5 +1,6 @@
 # Copyright 2021 Aisha Tammy
 # Copyright 2021 Erik Rodriguez
+# Copyright 2022 Ryan Fox
 # Distributed under the terms of the ISC License
 
 EAPI=7
@@ -42,8 +43,8 @@ BDEPEND="
 src_configure() {
 	local emesonargs=(
 		-Dwerror=false
-		-Dpng-backend=$(usex png none libpng)
-		-Dsvg-backend=$(usex svg none librsvg)
+		-Dpng-backend=$(usex png libpng none)
+		-Dsvg-backend=$(usex svg librsvg none)
 		$(meson_feature cairo enable-cairo)
 	)
 	meson_src_configure

--- a/gui-apps/fuzzel/fuzzel-9999.ebuild
+++ b/gui-apps/fuzzel/fuzzel-9999.ebuild
@@ -8,11 +8,11 @@ EAPI=7
 inherit meson xdg
 
 DESCRIPTION="Application launcher similar to rofi's 'drun' mode"
-HOMEPAGE="https://codeberg.org/dnkl/yambar"
+HOMEPAGE="https://codeberg.org/dnkl/fuzzel"
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://codeberg.org/dnkl/fuzzel"
+	EGIT_REPO_URI="https://codeberg.org/dnkl/fuzzel.git"
 else
 	SRC_URI="https://codeberg.org/dnkl/fuzzel/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}"/${PN}


### PR DESCRIPTION
Previously, enabling the png and svg USE flags disabled their corresponding backends.