### PR TITLE
Changed zig to version 0.9.0 for river.

### DIFF
--- a/gui-wm/river/river-0.1.3.ebuild
+++ b/gui-wm/river/river-0.1.3.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	>=dev-lang/zig-0.9.1
+	>=dev-lang/zig-0.9.0
 	dev-libs/wayland-protocols
 	virtual/pkgconfig
 	app-text/scdoc

--- a/gui-wm/river/river-9999.ebuild
+++ b/gui-wm/river/river-9999.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	>=dev-lang/zig-0.9.1
+	>=dev-lang/zig-0.9.0
 	dev-libs/wayland-protocols
 	virtual/pkgconfig
 	app-text/scdoc


### PR DESCRIPTION
If using >=zig-0.9.1 portage emerges zig 0.10.xx-xx, which fails to compile river.

It compiles fine using zig-0.9.0 though, so I see no reason why not to use it. :p 
