### PR TITLE
fix: gui-libs/wlroots only if USE=system-wlroots

### DIFF
--- a/gui-wm/hyprland/hyprland-0.23.0.ebuild
+++ b/gui-wm/hyprland/hyprland-0.23.0.ebuild
@@ -47,7 +47,9 @@ DEPEND="
 		x11-libs/libxcb
 		x11-base/xwayland
 	)
-	gui-libs/wlroots:=[X?]
+	system-wlroots? (
+		gui-libs/wlroots:=[X?]
+	)
 "
 
 RDEPEND="

--- a/gui-wm/hyprland/hyprland-0.23.0.ebuild
+++ b/gui-wm/hyprland/hyprland-0.23.0.ebuild
@@ -50,6 +50,24 @@ DEPEND="
 	system-wlroots? (
 		gui-libs/wlroots:=[X?]
 	)
+	!system-wlroots? (
+		dev-libs/wayland-protocols:=[X?]
+		media-libs/libdisplay-info
+		sys-apps/hwdata
+		sys-auth/seatd
+		virtual/libudev
+		dev-util/glslang
+		dev-util/vulkan-headers
+		media-libs/vulkan-loader
+		x11-libs/xcb-util-image
+		x11-libs/xcb-util-renderutil
+		x11-libs/xcb-util-wm
+		dev-util/meson
+		dev-util/wayland-scanner
+		virtual/pkgconfig
+		dev-util/ninja
+		dev-util/meson-format-array
+	}
 "
 
 RDEPEND="

--- a/gui-wm/hyprland/hyprland-0.23.0.ebuild
+++ b/gui-wm/hyprland/hyprland-0.23.0.ebuild
@@ -51,7 +51,6 @@ DEPEND="
 		gui-libs/wlroots:=[X?]
 	)
 	!system-wlroots? (
-		dev-libs/wayland-protocols:=[X?]
 		media-libs/libdisplay-info
 		sys-apps/hwdata
 		sys-auth/seatd
@@ -64,7 +63,6 @@ DEPEND="
 		x11-libs/xcb-util-wm
 		dev-util/meson
 		dev-util/wayland-scanner
-		virtual/pkgconfig
 		dev-util/ninja
 		dev-util/meson-format-array
 	}


### PR DESCRIPTION
Hyprland packages it's own version of wlroots.
we only need to pull from other repo's if we're using the system-wlroots

relates to [Issue: #53](https://github.com/bsd-ac/wayland-desktop/issues/53)