### PR TITLE
gui-wm/river: Removed = subslot operator

### DIFF
--- a/gui-wm/river/river-0.2.3.ebuild
+++ b/gui-wm/river/river-0.2.3.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	|| ( >=dev-lang/zig-0.10.0 >=dev-lang/zig-bin-0.10.0 )
+	|| ( dev-lang/zig:0.10 dev-lang/zig-bin:0.10 )
 	dev-libs/wayland-protocols
 	man? ( app-text/scdoc )
 	virtual/pkgconfig

--- a/gui-wm/river/river-0.2.4.ebuild
+++ b/gui-wm/river/river-0.2.4.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	|| ( >=dev-lang/zig-0.10.0 >=dev-lang/zig-bin-0.10.0 )
+	|| ( dev-lang/zig:0.10 dev-lang/zig-bin:0.10 )
 	dev-libs/wayland-protocols
 	man? ( app-text/scdoc )
 	virtual/pkgconfig

--- a/gui-wm/river/river-9999.ebuild
+++ b/gui-wm/river/river-9999.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	dev-libs/libevdev
 	dev-libs/libinput
 	dev-libs/wayland
-	>=gui-libs/wlroots-0.16.0:0/16=[X]
+	>=gui-libs/wlroots-0.16.0:0/16[X]
 	x11-libs/cairo[X]
 	x11-libs/libxkbcommon:=[X]
 	x11-libs/pixman

--- a/gui-wm/river/river-9999.ebuild
+++ b/gui-wm/river/river-9999.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	|| ( >=dev-lang/zig-0.10 >=dev-lang/zig-bin-0.10 )
+	|| ( dev-lang/zig:0.10 dev-lang/zig-bin:0.10 )
 	dev-libs/wayland-protocols
 	virtual/pkgconfig
 	app-text/scdoc


### PR DESCRIPTION
The `=` operator makes no sense for the live version of river, since it says subslot changes should trigger rebuild, and the subslot is explicit in the live version.

Additionnally, Zig version is specified now by subslot rather than >= dependency, which locks the Zig version to 0.10 (the only version you can build river with)