### PR TITLE
gui-wm/river: Fix wlroots dependency.

### DIFF
--- a/gui-wm/river/river-0.2.6.ebuild
+++ b/gui-wm/river/river-0.2.6.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="Dynamic tiling wayland compositor"
 HOMEPAGE="https://github.com/riverwm/river"
 
 SRC_URI="https://github.com/riverwm/river/releases/download/v${PV}/${P}.tar.gz"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/gui-wm/river/river-0.2.6.ebuild
+++ b/gui-wm/river/river-0.2.6.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-libs/libevdev
 	dev-libs/libinput
 	dev-libs/wayland
-	>=gui-libs/wlroots-0.16.0:=[X?]
+	=gui-libs/wlroots-0.16*:=[X?]
 	x11-libs/libxkbcommon:=[X?]
 	x11-libs/pixman
 "


### PR DESCRIPTION
River 0.2.6 will not build against wlroots 0.17.

Found this issue with the ebuild I submitted Yesterday. When building against wlroots 0.17, I would get an error message like this:
```
Build Summary: 29/32 steps succeeded; 1 failed (disable with --summary none)
install transitive failure
└─ install river transitive failure
   └─ zig build-exe river ReleaseSafe native 3 errors
deps/zig-wlroots/src/wlroots.zig:190:9: error: zig-wlroots requires wlroots version 0.16
        @compileError("zig-wlroots requires wlroots version 0.16");
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
deps/zig-wlroots/src/render/drm_format_set.zig:2:11: error: C import failed
const c = @cImport(@cInclude("wlr/render/drm_format_set.h"));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/wlr/render/drm_format_set.h:6:2: error: "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
```

Going back to wlroots 0.16 resolved the issue.