### PR TITLE
gui-wm/river: move remotes to codeberg repository

### DIFF
--- a/gui-wm/river/metadata.xml
+++ b/gui-wm/river/metadata.xml
@@ -6,6 +6,6 @@
 		<name>Aisha Tammy</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">rivervm/river</remote-id>
+		<remote-id type="codeberg">river/river</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/gui-wm/river/river-0.2.6.ebuild
+++ b/gui-wm/river/river-0.2.6.ebuild
@@ -6,13 +6,13 @@ EAPI=8
 inherit edo
 
 DESCRIPTION="Dynamic tiling wayland compositor"
-HOMEPAGE="https://github.com/riverwm/river"
+HOMEPAGE="https://codeberg.org/river/river"
 
-SRC_URI="https://github.com/riverwm/river/releases/download/v${PV}/${P}.tar.gz"
-KEYWORDS="~amd64 ~arm64"
-
+SRC_URI="https://codeberg.org/river/river/releases/download/v${PV}/${P}.tar.gz"
 LICENSE="GPL-3"
 SLOT="0"
+KEYWORDS="~amd64 ~arm64"
+
 IUSE="+man pie test +X"
 RESTRICT="!test? ( test )"
 

--- a/gui-wm/river/river-9999.ebuild
+++ b/gui-wm/river/river-9999.ebuild
@@ -8,13 +8,13 @@ EAPI=8
 #       first do the install to a temporary directory
 
 DESCRIPTION="Dynamic tiling wayland compositor"
-HOMEPAGE="https://github.com/riverwm/river"
+HOMEPAGE="https://codeberg.org/river/river"
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/riverwm/river"
+	EGIT_REPO_URI="https://codeberg.org/river/river"
 else
-	SRC_URI="https://github.com/riverwm/river/releases/download/v${PV}/${P}.tar.gz"
+	SRC_URI="https://codeberg.org/river/river/releases/download/v${PV}/${P}.tar.gz"
 	KEYWORDS="~amd64"
 fi
 


### PR DESCRIPTION
River's main repository moved to Codeberg and now the GitHub repo is a read-only mirror. This commit switches to using the Codeberg repository for fetching sources.