### PR TITLE
gui-apps/river-tag-overlay: Fix license identifier.

### DIFF
--- a/gui-apps/river-tag-overlay/river-tag-overlay-1.0.0-r1.ebuild
+++ b/gui-apps/river-tag-overlay/river-tag-overlay-1.0.0-r1.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://git.sr.ht/~leon_plickat/${PN}/archive/v${PV}.tar.gz -> ${P}.tar
 
 S="${WORKDIR}"/${PN}-v${PV}
 
-LICENSE="GPLv3"
+LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~arm64 ~amd64"
 


### PR DESCRIPTION
This fixes #113.

Thank you @robertgzr for reporting.