### PR TITLE
gui-apps/qtgreet: add dependency and address QA notices

### DIFF
--- a/gui-apps/qtgreet/qtgreet-2.0.2.ebuild
+++ b/gui-apps/qtgreet/qtgreet-2.0.2.ebuild
@@ -1,3 +1,4 @@
+# Copyright 2025 James Dominy
 # Copyright 2021-2023 Aisha Tammy
 # Copyright 2021 Ichika Zou
 # Distributed under the terms of the ISC License
@@ -27,6 +28,7 @@ CDEPEND="
 	dev-libs/json-c
 	dev-libs/wayland
 	media-video/mpv:=
+	x11-misc/lightdm
 	x11-libs/libxkbcommon:=
 	greetwl? ( gui-libs/wlroots:0/17 )
 	qt5? (

--- a/gui-apps/qtgreet/qtgreet-2.0.2.ebuild
+++ b/gui-apps/qtgreet/qtgreet-2.0.2.ebuild
@@ -5,7 +5,7 @@
 
 EAPI=8
 
-inherit meson
+inherit meson xdg-utils
 
 DESCRIPTION="QT based greeter for greetd"
 HOMEPAGE="https://gitlab.com/marcusbritanicus/QtGreet"
@@ -77,4 +77,12 @@ src_configure() {
 src_install() {
 	meson_src_install
 	keepdir "/var/lib/qtgreet"
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/gui-apps/qtgreet/qtgreet-9999.ebuild
+++ b/gui-apps/qtgreet/qtgreet-9999.ebuild
@@ -1,3 +1,4 @@
+# Copyright 2025 James Dominy
 # Copyright 2021-2023 Aisha Tammy
 # Copyright 2021 Ichika Zou
 # Distributed under the terms of the ISC License
@@ -27,6 +28,7 @@ CDEPEND="
 	dev-libs/json-c
 	dev-libs/wayland
 	media-video/mpv:=
+	x11-misc/lightdm
 	x11-libs/libxkbcommon:=
 	greetwl? ( gui-libs/wlroots:0/18 )
 	qt5? (

--- a/gui-apps/qtgreet/qtgreet-9999.ebuild
+++ b/gui-apps/qtgreet/qtgreet-9999.ebuild
@@ -5,7 +5,7 @@
 
 EAPI=8
 
-inherit meson
+inherit meson xdg-utils
 
 DESCRIPTION="QT based greeter for greetd"
 HOMEPAGE="https://gitlab.com/marcusbritanicus/QtGreet"
@@ -77,4 +77,12 @@ src_configure() {
 src_install() {
 	meson_src_install
 	keepdir "/var/lib/qtgreet"
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }


### PR DESCRIPTION
QtGreet has introduced a dependency on liblightdm-gobject-1.so (provided by x11-misc/lightdm) and also has some QA notices regarding the icon cache. This PR adds the required dependency and address the QA notices