### PR TITLE
Update wayqt-0.2.0-r1.ebuild - do not need linguist-tools

### DIFF
--- a/gui-libs/wayqt/wayqt-0.2.0-r1.ebuild
+++ b/gui-libs/wayqt/wayqt-0.2.0-r1.ebuild
@@ -40,7 +40,6 @@ RDEPEND="
 "
 BDEPEND="
 	dev-libs/wayland-protocols
-	dev-qt/linguist-tools:5
 	virtual/pkgconfig
 "
 


### PR DESCRIPTION
linguist-tools is not needed to build this, gentoo is now removing qt5, lets remove the dep